### PR TITLE
fix: del static for finger\Database\Connection->close

### DIFF
--- a/Yaf-Admin/library/finger/Database/Connection.php
+++ b/Yaf-Admin/library/finger/Database/Connection.php
@@ -118,7 +118,7 @@ class Connection
      *
      * @return void
      */
-    final public static function close($dbOption = '')
+    final public function close($dbOption = '')
     {
         if (strlen($dbOption) == 0) {
             $dbOption = $this->dbOption;

--- a/Yaf-Server/library/finger/Database/Connection.php
+++ b/Yaf-Server/library/finger/Database/Connection.php
@@ -118,7 +118,7 @@ class Connection
      *
      * @return void
      */
-    final public static function close($dbOption = '')
+    final public function close($dbOption = '')
     {
         if (strlen($dbOption) == 0) {
             $dbOption = $this->dbOption;


### PR DESCRIPTION
修改内容: 去掉 close 方法的 static 修饰词
原因: 不应接受静态调用，关闭的应是某个实例。如果需要静态调用，则需要更改源码，方法体中$this无效