### PR TITLE
thread class forbid clone

### DIFF
--- a/Yaf-Admin/library/finger/Thread/Thread.php
+++ b/Yaf-Admin/library/finger/Thread/Thread.php
@@ -37,6 +37,13 @@ abstract class Thread
     }
 
     /**
+     * 防止克隆导致单例失败。
+     *
+     * @return void
+     */
+    private function __clone(){}
+
+    /**
      * 单例对象实现。
      * @param  integer $threadNum 线程数量。
      * @return instance

--- a/Yaf-Server/library/finger/Thread/Thread.php
+++ b/Yaf-Server/library/finger/Thread/Thread.php
@@ -37,6 +37,13 @@ abstract class Thread
     }
 
     /**
+     * 防止克隆导致单例失败。
+     *
+     * @return void
+     */
+    private function __clone(){}
+
+    /**
      * 单例对象实现。
      * @param  integer $threadNum 线程数量。
      * @return instance


### PR DESCRIPTION
修改内容: Thread 抽象基类，使用 private 修饰 __clone
原因:  所有实现的进程都属于单例，不允许clone